### PR TITLE
Add filters to crop and resize source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add a progress bar for the `diff` function.
 - Fix bug where some codecs may not return the final frame.
+- Add ability to crop and resize `diff` sources.
 
 ## Version 0.1.0-beta.5
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
+
+[[package]]
 name = "cc"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.23"
+version = "4.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb41c13df48950b20eb4cd0eefa618819469df1bffc49d11e8487c4ba0037e5"
+checksum = "60494cedb60cb47462c0ff7be53de32c0e42a6fc2c772184554fa12bd9489c03"
 dependencies = [
  "atty",
  "bitflags",
@@ -333,6 +348,7 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "tempfile",
+ "video-resize",
 ]
 
 [[package]]
@@ -448,6 +464,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +494,21 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20bd243ab3dbb395b39ee730402d2e5405e448c75133ec49cc977762c4cba3d1"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
 ]
 
 [[package]]
@@ -501,6 +541,15 @@ checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+dependencies = [
  "num-traits",
 ]
 
@@ -617,6 +666,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "peeking_take_while"
@@ -752,6 +807,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +876,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "safe_arch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +930,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -954,6 +1037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,10 +1081,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "video-resize"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171b158d85a519e8ef934fadf88df425f3dea2bc0b1160ec64f1b99f315d91fb"
+dependencies = [
+ "anyhow",
+ "nalgebra",
+ "num-traits",
+ "v_frame",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wide"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae41ecad2489a1655c8ef8489444b0b113c0a0c795944a3572a0931cf7d2525c"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ num-rational = "0.4.1"
 num-traits = "0.2.15"
 num_enum = "0.5.7"
 pretty_env_logger = "0.4.0"
+video-resize = "0.1.0"
 
 [dev-dependencies]
 interpolate_name = "0.2.3"

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,0 +1,172 @@
+use anyhow::{anyhow, bail, Result};
+use av1_grain::v_frame::{frame::Frame, prelude::Pixel};
+use video_resize::algorithms::{
+    BicubicCatmullRom, BicubicHermite, BicubicMitchell, Lanczos3, Spline36,
+};
+use video_resize::{crop, resize, CropDimensions, ResizeDimensions};
+
+pub struct FilterChain {
+    filters: Vec<Filter>,
+}
+
+impl FilterChain {
+    pub fn new(filters: &str) -> Result<Self> {
+        if filters.is_empty() {
+            return Ok(Self {
+                filters: Vec::new(),
+            });
+        }
+
+        let mut parsed = Vec::new();
+        for filter in filters.split(';') {
+            let (filter, args) = filter
+                .split_once(':')
+                .ok_or_else(|| anyhow!("Invalid filter syntax in \"{}\"", filter))?;
+            let args = args.split(',');
+            match filter {
+                "crop" => {
+                    let (mut top, mut bottom, mut left, mut right) = (0, 0, 0, 0);
+                    for arg in args {
+                        let (arg, value) = arg
+                            .split_once('=')
+                            .ok_or_else(|| anyhow!("Invalid filter syntax in \"{}\"", arg))?;
+                        match arg {
+                            "top" => {
+                                top = value.parse()?;
+                            }
+                            "bottom" => {
+                                bottom = value.parse()?;
+                            }
+                            "left" => {
+                                left = value.parse()?;
+                            }
+                            "right" => {
+                                right = value.parse()?;
+                            }
+                            arg => bail!("Unrecognized crop arg \"{}\"", arg),
+                        }
+                    }
+                    parsed.push(Filter::Crop {
+                        top,
+                        bottom,
+                        left,
+                        right,
+                    });
+                }
+                "resize" => {
+                    let (mut width, mut height, mut alg) = (0, 0, "catmullrom");
+                    for arg in args {
+                        let (arg, value) = arg
+                            .split_once('=')
+                            .ok_or_else(|| anyhow!("Invalid filter syntax in \"{}\"", arg))?;
+                        match arg {
+                            "width" => {
+                                width = value.parse()?;
+                            }
+                            "height" => {
+                                height = value.parse()?;
+                            }
+                            "alg" => match value {
+                                "hermite" => {
+                                    alg = "hermite";
+                                }
+                                "catmullrom" => {
+                                    alg = "catmullrom";
+                                }
+                                "mitchell" => {
+                                    alg = "mitchell";
+                                }
+                                "lanczos" => {
+                                    alg = "lanczos";
+                                }
+                                "spline36" => {
+                                    alg = "spline36";
+                                }
+                                alg => bail!("Unrecognized resize algorithm \"{}\"", alg),
+                            },
+                            arg => bail!("Unrecognized resize arg \"{}\"", arg),
+                        }
+                    }
+                    if width == 0 || height == 0 {
+                        bail!("Both width and height must be provided to resize filter");
+                    }
+                    parsed.push(Filter::Resize { width, height, alg });
+                }
+                f => bail!("Unrecognized filter \"{}\"", f),
+            }
+        }
+
+        Ok(Self { filters: parsed })
+    }
+
+    pub fn apply<T: Pixel>(&self, frame: Frame<T>, source_bd: usize) -> Frame<T> {
+        self.filters
+            .iter()
+            .fold(frame, |prev, f| f.apply(&prev, source_bd))
+    }
+}
+
+enum Filter {
+    Crop {
+        top: usize,
+        bottom: usize,
+        left: usize,
+        right: usize,
+    },
+    Resize {
+        width: usize,
+        height: usize,
+        alg: &'static str,
+    },
+}
+
+impl Filter {
+    pub fn apply<T: Pixel>(&self, frame: &Frame<T>, source_bd: usize) -> Frame<T> {
+        match *self {
+            Filter::Crop {
+                top,
+                bottom,
+                left,
+                right,
+            } => crop(
+                frame,
+                CropDimensions {
+                    top,
+                    bottom,
+                    left,
+                    right,
+                },
+            )
+            .unwrap(),
+            Filter::Resize { width, height, alg } => match alg {
+                "hermite" => resize::<T, BicubicHermite>(
+                    frame,
+                    ResizeDimensions { width, height },
+                    source_bd,
+                )
+                .unwrap(),
+                "catmullrom" => resize::<T, BicubicCatmullRom>(
+                    frame,
+                    ResizeDimensions { width, height },
+                    source_bd,
+                )
+                .unwrap(),
+                "mitchell" => resize::<T, BicubicMitchell>(
+                    frame,
+                    ResizeDimensions { width, height },
+                    source_bd,
+                )
+                .unwrap(),
+                "lanczos" => {
+                    resize::<T, Lanczos3>(frame, ResizeDimensions { width, height }, source_bd)
+                        .unwrap()
+                }
+                "spline36" => {
+                    resize::<T, Spline36>(frame, ResizeDimensions { width, height }, source_bd)
+                        .unwrap()
+                }
+                _ => unreachable!(),
+            },
+        }
+    }
+}


### PR DESCRIPTION
This is useful for when the encode has been cropped or resized, and it is necessary to match the source resolution to the encode resolution.