### PR TITLE
Fetch source and denoised frames in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "pretty_env_logger",
  "quickcheck",
  "quickcheck_macros",
+ "scoped_threadpool",
  "tempfile",
  "video-resize",
 ]
@@ -814,6 +815,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ num-rational = "0.4.1"
 num-traits = "0.2.15"
 num_enum = "0.5.7"
 pretty_env_logger = "0.4.0"
+scoped_threadpool = "0.1.9"
 video-resize = "0.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Unfortunately the diff algorithm itself is quite difficult to parallelize, so we have to find other ways to utilize SMP. This seems to provide about a 5% wall time speedup.