### PR TITLE
Extend packet to include adjustment obu size

### DIFF
--- a/src/parser/obu.rs
+++ b/src/parser/obu.rs
@@ -165,6 +165,7 @@ impl<const WRITE: bool> BitstreamParser<WRITE> {
                         }
                     }
                     let adjustment = obu_size - (pre_len - input.len());
+                    self.packet_out.extend(input.iter().take(adjustment));
                     input = &input[adjustment..];
                 }
 


### PR DESCRIPTION
Fixes this bug:
```
INFO  grav1synth::parser > LOOP START: stream_index 0, video_index 0
 INFO  grav1synth::parser > obu:Some(FrameHeader(FrameHeader { show_frame: true, show_existing_frame: true, film_grain_params: CopyRefFrame, tile_info: TileInfo { tile_cols: 2, tile_rows: 1, tile_cols_log2: 1, tile_rows_log2: 1 } }))
 INFO  grav1synth::parser > Packet in data Some([26, 2, 232, 0])
 INFO  grav1synth::parser > Package in size 4
 INFO  grav1synth::parser > Package out len 3
 INFO  grav1synth::parser > Shrinking packet from 4 to 3
 INFO  grav1synth::parser > Packet out [26, 2, 232]
[matroska @ 0x155e2fc70] Error when reformatting data of a packet from stream 0.
```

There are instances where a packet appears in the following form: [26, 2, 232, 0] (I suspect this is caused by encoding with tiles, though I'm not sure). After parsing the obu, the packet is reduced to [26, 2, 232], which results in a mismatch with the obu size of 2.

This line of code `self.packet_out.extend(input.iter().take(adjustment));` uses the adjustment of the obu size that changes the input to also change the packet size.

I have tested with different videos and this fixed the mismatch of the obu size.