### PR TITLE
Add support for ffmpeg 8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -143,9 +143,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitvec"
@@ -365,9 +365,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ffmpeg-sys-the-third"
-version = "3.0.0+ffmpeg-7.1"
+version = "4.0.0+ffmpeg-8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ac7541c97a452897b3b85648e2e6fcd862c272ea0085ee3cbd7c7e2cfed95b"
+checksum = "7fc211d0448e9ba775923b7cac39c19d350b47b4994b658f096cd0232d09ef97"
 dependencies = [
  "bindgen",
  "cc",
@@ -379,11 +379,11 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-the-third"
-version = "3.0.0+ffmpeg-7.1"
+version = "4.0.0+ffmpeg-8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dbce2b0c6663228674377831caa539c1caad83d66b989986472b5782a6429e9"
+checksum = "3839654c07a1447e03e920bf33e6fca1de1a97f4df72c17c8765c47e89fd0ef9"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.10.0",
  "ffmpeg-sys-the-third",
  "libc",
 ]
@@ -542,9 +542,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libloading"
@@ -815,7 +815,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -859,7 +859,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "grav1synth"
 version = "0.1.0-beta.6"
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.65.0"
 license = "MIT"
 repository = "https://github.com/rust-av/grav1synth"
 description = "Grain Synth analyzer and editor for AV1 files"
@@ -19,7 +19,7 @@ bitvec = "1.0.1"
 clap = { version = "4.0.2", features = ["derive"] }
 crossterm = "0.26.0"
 dialoguer = "0.10.1"
-ffmpeg = { version = "3.0.0", default-features = false, features = [
+ffmpeg = { version = "4.0.0", default-features = false, features = [
     "format",
 ], package = "ffmpeg-the-third"}
 indicatif = "0.17.1"


### PR DESCRIPTION
Update ffmpeg-the-third version for ffmpeg 8.0 support
Increase rust version to match minimum version for ffmpeg-the-third dependedncy MSRV