### PR TITLE
Remove ISO range limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Reads `my_encode.mkv`, adds film grain to it based on `grain_file.txt`, and outp
 
 ### `grav1synth generate my_encode.mkv -o grainy_encode.mkv --iso 400 --chroma`
 
-Reads `my_encode.mkv`, adds photon-noise-based film grain to it based on the strength provided by `--iso` (up to `6400`), and outputs the video to `grainy_encode.mkv`. By default applies grain to only the luma plane. `--chroma` enables grain on chroma planes as well.
+Reads `my_encode.mkv`, adds photon-noise-based film grain to it based on the strength provided by `--iso` (up to `4294967295`), and outputs the video to `grainy_encode.mkv`. By default applies grain to only the luma plane. `--chroma` enables grain on chroma planes as well.
 
 ### `grav1synth remove my_encode.mkv -o clean_encode.mkv`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -870,9 +870,9 @@ pub enum Commands {
         /// Overwrite the output file without prompting.
         #[clap(long, short = 'y')]
         overwrite: bool,
-        /// ISO strength (100-6400) for the generated grain.
-        #[clap(long, value_parser = clap::value_parser!(u16).range(1..=6400))]
-        iso: u16,
+        /// ISO strength (1-4294967295) for the generated grain. Values between 100-6400 are recommended.
+        #[clap(long, value_parser = clap::value_parser!(u32).range(1..))]
+        iso: u32,
         /// Whether to apply grain to the chroma planes as well.
         #[clap(long)]
         chroma: bool,


### PR DESCRIPTION
Increase maximum ISO from `6400` to `u32::MAX`. Higher ISO strengths can also be achieved with higher width and height values. A more exact limit could be defined but I personally have no understanding of the Film Grain specification so I simply changed the u16 to u32.

The previous limit of 100-6400 has been changed to a recommendation in the `--help` output.

Thanks,
\- Boats M.