### PR TITLE
Add output-table to generate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Reads `my_encode.mkv` and outputs a film grain table file at `grain_file.txt`
 
 Reads `my_encode.mkv`, adds film grain to it based on `grain_file.txt`, and outputs the video to `grainy_encode.mkv`
 
-### `grav1synth generate my_encode.mkv -o grainy_encode.mkv --iso 400 --chroma`
+### `grav1synth generate my_encode.mkv -o grainy_encode.mkv --iso 400 --chroma --output-table grain_file.txt`
 
-Reads `my_encode.mkv`, adds photon-noise-based film grain to it based on the strength provided by `--iso` (up to `6400`), and outputs the video to `grainy_encode.mkv`. By default applies grain to only the luma plane. `--chroma` enables grain on chroma planes as well.
+Reads `my_encode.mkv`, adds photon-noise-based film grain to it based on the strength provided by `--iso` (up to `6400`), and outputs the video to `grainy_encode.mkv`. By default applies grain to only the luma plane. `--chroma` enables grain on chroma planes as well. `--output-table` will write the generated grain table to the specified file.
 
 ### `grav1synth remove my_encode.mkv -o clean_encode.mkv`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,6 +284,7 @@ pub fn main() -> Result<()> {
         Commands::Generate {
             input,
             output,
+            output_table,
             overwrite,
             iso,
             chroma,
@@ -340,6 +341,12 @@ pub fn main() -> Result<()> {
                     random_seed: None,
                 },
             );
+            if let Some(path) = output_table {
+                let mut output_file = BufWriter::new(File::create(&path)?);
+                writeln!(output_file, "filmgrn1")?;
+                write_film_grain_segment(&grain_data.clone().into(), &mut output_file)?;
+            }
+
             let mut parser: BitstreamParser<true> =
                 BitstreamParser::with_writer(reader, writer, Some(vec![grain_data.into()]));
 
@@ -867,6 +874,9 @@ pub enum Commands {
         /// The path to write the grain-synthed AV1 file to.
         #[clap(long, short, value_parser)]
         output: PathBuf,
+        /// The path to write the generated film grain table to.
+        #[clap(long, short, value_parser)]
+        output_table: Option<PathBuf>,
         /// Overwrite the output file without prompting.
         #[clap(long, short = 'y')]
         overwrite: bool,


### PR DESCRIPTION
Allows the user to specify a file path for the `generate` command to output the generated Film Grain table to. Convenient for when the user wants a table based on the input video but does not want to rely on using the `inspect` command to extract the table.

Thanks,
\- Boats M.