### PR TITLE
Add custom coefficients for cY, cCb, and cCr

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Reads `my_encode.mkv` and outputs a film grain table file at `grain_file.txt`
 
 Reads `my_encode.mkv`, adds film grain to it based on `grain_file.txt`, and outputs the video to `grainy_encode.mkv`
 
-### `grav1synth generate my_encode.mkv -o grainy_encode.mkv --iso 400 --chroma`
+### `grav1synth generate my_encode.mkv -o grainy_encode.mkv --iso 400 --chroma --ccy "3 -6 3 4 6 6 -5 -7 11 2 -13 -24 -4 8 4 6 -32 35 30 -6 -4 10 -38 67"`
 
-Reads `my_encode.mkv`, adds photon-noise-based film grain to it based on the strength provided by `--iso` (up to `6400`), and outputs the video to `grainy_encode.mkv`. By default applies grain to only the luma plane. `--chroma` enables grain on chroma planes as well.
+Reads `my_encode.mkv`, adds photon-noise-based film grain to it based on the strength provided by `--iso` (up to `6400`), and outputs the video to `grainy_encode.mkv`. By default applies grain to only the luma plane. `--chroma` enables grain on chroma planes as well. `--ccy`, `--ccb`, and `--ccr` specify the custom AR coefficients for luma, Cb, and Cr planes, respectively.
 
 ### `grav1synth remove my_encode.mkv -o clean_encode.mkv`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ use std::{
 };
 
 use anyhow::{bail, Result};
+use arrayvec::ArrayVec;
 #[cfg(feature = "unstable")]
 use av1_grain::estimate_plane_noise;
 use av1_grain::{
@@ -287,6 +288,9 @@ pub fn main() -> Result<()> {
             overwrite,
             iso,
             chroma,
+            custom_cy,
+            custom_ccb,
+            custom_ccr,
         } => {
             if input == output {
                 error!(
@@ -323,7 +327,7 @@ pub fn main() -> Result<()> {
                 )
             };
 
-            let grain_data = generate_photon_noise_params(
+            let mut grain_data = generate_photon_noise_params(
                 0,
                 u64::MAX,
                 av1_grain::NoiseGenArgs {
@@ -340,6 +344,30 @@ pub fn main() -> Result<()> {
                     random_seed: None,
                 },
             );
+
+            fn parse_coefficients(s: &str, capacity: usize) -> Vec<i8> {
+                s.split_whitespace()
+                    .map(|s| s.parse::<i8>().ok())
+                    .filter(|x| x.is_some())
+                    .map(|x| x.unwrap())
+                    .take(capacity)
+                    .collect()
+            }
+            if let Some(y) = custom_cy {
+                let y_vec = parse_coefficients(&y, 24);
+                grain_data.ar_coeffs_y = ArrayVec::try_from(y_vec.as_slice())
+                    .expect("Failed to parse coefficients for cY");
+            }
+            if let Some(cb) = custom_ccb {
+                let cb_vec: Vec<i8> = parse_coefficients(&cb, 25);
+                grain_data.ar_coeffs_cb = ArrayVec::try_from(cb_vec.as_slice())
+                    .expect("Failed to parse coefficients for cCb");
+            }
+            if let Some(cr) = custom_ccr {
+                let cr_vec: Vec<i8> = parse_coefficients(&cr, 25);
+                grain_data.ar_coeffs_cr = ArrayVec::try_from(cr_vec.as_slice())
+                    .expect("Failed to parse coefficients for cCr");
+            }
             let mut parser: BitstreamParser<true> =
                 BitstreamParser::with_writer(reader, writer, Some(vec![grain_data.into()]));
 
@@ -876,6 +904,15 @@ pub enum Commands {
         /// Whether to apply grain to the chroma planes as well.
         #[clap(long)]
         chroma: bool,
+        /// The custom AR coefficients for luma scaling points (cY).
+        #[clap(long("cy"), allow_hyphen_values = true)]
+        custom_cy: Option<String>,
+        /// The custom AR coefficients for Cb scaling points (cCb).
+        #[clap(long("ccb"), allow_hyphen_values = true)]
+        custom_ccb: Option<String>,
+        /// The custom AR coefficients for Cr scaling points (cCr).
+        #[clap(long("ccr"), allow_hyphen_values = true)]
+        custom_ccr: Option<String>,
     },
     /// Removes all film grain from a given AV1 video,
     /// and outputs it at a given `output` path.


### PR DESCRIPTION
The coefficients for the luma, Cb, and Cr planes are hard-coded to 0. This PR allows the user to specify their own coefficients to tweak the characteristics of the Film Grain table.

I have no understanding of the Film Grain specification so this is just an incremental improvement over defaulting to 0, allowing more variation in grain tables without having to extract the generated table, add the values manually, then apply them. Instead, I produce the values by using the `diff` command, parse the table, then call the `generate` command with the `--cy "VALUES" --ccb "VALUES" --ccy "VALUES"` arguments.

## Improvements

Initially, I tried to simply pass an existing film grain table file location to an `--existing` argument for the `generate` command to parse and replace the values but the parsing wasn't working as expected (no output or error). If the parsing issue could be resolved that would make the `generate` command cleaner and simplify usage.

Ideally, a set of inputs could be used to generate values besides defaulting to 0. Without an understanding of the specification, simply copying known good values is the best I can do.

Thanks,
\- Boats M.