### PR TITLE
Merge apply/generate into unified apply command with grain-overwrite protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+- Merge `apply` and `generate` into a single `apply` command. `--grain <FILE>` applies
+  table-based grain; `--iso <NUM>` (with optional `--chroma`) applies photon-noise-based grain.
+- `apply` now checks for existing grain headers before writing. If grain is already present it
+  prints a notice and skips, unless `--replace` is also provided. This makes it safe to use in
+  automated workflows where existing grain should be preserved.
+
 ## Version 0.2.0
 
 - Upgrade all of the internals to the latest rust-av crates

--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ Reads `my_encode.mkv` and outputs a film grain table file at `grain_file.txt`
 
 ### `grav1synth apply my_encode.mkv -o grainy_encode.mkv -g grain_file.txt`
 
-Reads `my_encode.mkv`, adds film grain to it based on `grain_file.txt`, and outputs the video to `grainy_encode.mkv`
+Reads `my_encode.mkv`, applies film grain from `grain_file.txt`, and outputs the video to `grainy_encode.mkv`.
 
-### `grav1synth generate my_encode.mkv -o grainy_encode.mkv --iso 400 --chroma`
+### `grav1synth apply my_encode.mkv -o grainy_encode.mkv --iso 400 --chroma`
 
-Reads `my_encode.mkv`, adds photon-noise-based film grain to it based on the strength provided by `--iso` (up to `4294967295`), and outputs the video to `grainy_encode.mkv`. By default applies grain to only the luma plane. `--chroma` enables grain on chroma planes as well.
+Reads `my_encode.mkv`, generates photon-noise-based film grain at the strength given by `--iso` (up to `4294967295`), and outputs the video to `grainy_encode.mkv`. By default grain is applied to the luma plane only; `--chroma` enables grain on chroma planes as well.
+
+In both forms, if the input already has film grain headers the command will print a notice and skip processing — add `--replace` to overwrite existing grain instead. This makes it safe to use in automated workflows where you want to protect videos that already have grain while still applying grain to those that do not.
 
 ### `grav1synth remove my_encode.mkv -o clean_encode.mkv`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use av1_grain::{
     DiffGenerator, TransferFunction, generate_photon_noise_params, parse_grain_table,
     v_frame::{frame::Frame, pixel::Pixel},
 };
-use clap::{Parser, Subcommand};
+use clap::{ArgGroup, Parser, Subcommand};
 use crossterm::tty::IsTty;
 use dialoguer::Confirm;
 use ffmpeg::{
@@ -290,21 +290,10 @@ pub fn main() -> Result<()> {
                     );
                     Some(vec![grain_data.into()])
                 }
-                (None, None) => {
-                    error!(
-                        "Must provide either --grain <FILE> or --iso <NUM> to specify the grain \
-                         source. Exiting."
-                    );
-                    return Ok(());
-                }
-                // clap's conflicts_with prevents both being set simultaneously, but handle it
-                // gracefully in case the logic is ever reached.
-                (Some(_), Some(_)) => {
-                    error!(
-                        "Cannot use --grain and --iso at the same time. Provide one or the \
-                         other. Exiting."
-                    );
-                    return Ok(());
+                // The ArgGroup on the Apply variant guarantees exactly one of grain/iso is
+                // Some, so neither of these branches can be reached at runtime.
+                (None, None) | (Some(_), Some(_)) => {
+                    unreachable!("clap ArgGroup enforces exactly one of --grain or --iso")
                 }
             };
 
@@ -778,6 +767,11 @@ fn aggregate_grain_headers(
 }
 
 #[derive(Parser, Debug)]
+#[command(
+    about = "Grain synth analyzer and editor for AV1 files",
+    version,
+    flatten_help = true,
+)]
 pub struct Args {
     #[clap(subcommand)]
     command: Commands,
@@ -785,24 +779,33 @@ pub struct Args {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// Outputs a film grain table corresponding to a given AV1 video,
-    /// or reports if there is no film grain information.
+    /// Read the film grain table from an AV1 video and write it to a file.
+    ///
+    /// Reports if the video has no film grain synthesis enabled.
     Inspect {
         /// The AV1 file to inspect.
         #[clap(value_parser)]
         input: PathBuf,
-        /// The path to the output film grain table.
+        /// The path to write the film grain table to.
         #[clap(long, short, value_parser)]
         output: PathBuf,
         /// Overwrite the output file without prompting.
         #[clap(long, short = 'y')]
         overwrite: bool,
     },
-    /// Applies film grain to a given AV1 video and outputs it at a given `output` path.
+    /// Applies film grain from a provided grain-table or generated photon-noise-based grain to a given AV1 video and outputs it at a given `output` path.
     ///
-    /// Provide either `--grain` to use a grain table file, or `--iso` to generate
-    /// photon-noise-based grain. If the input already has film grain headers, processing
-    /// is skipped unless `--replace` is also provided.
+    /// Exactly one grain source must be provided:
+    ///   --grain <FILE>   apply grain from a table file
+    ///   --iso <NUM>      generate photon-noise-based grain (luma only by default add --chroma to apply color grain)
+    ///
+    /// If the input already has film grain headers the command skips by default.
+    /// Pass --replace to overwrite existing grain instead.
+    #[command(group(
+        ArgGroup::new("grain_source")
+            .required(true)
+            .args(["grain", "iso"])
+    ))]
     Apply {
         /// The AV1 file to apply grain to.
         #[clap(value_parser)]
@@ -813,44 +816,46 @@ pub enum Commands {
         /// Overwrite the output file without prompting.
         #[clap(long, short = 'y')]
         overwrite: bool,
-        /// The path to a film grain table file to apply (mutually exclusive with --iso).
-        #[clap(long, short, value_parser, conflicts_with = "iso")]
+        /// Path to a film grain table file.
+        /// Cannot be used together with --iso.
+        #[clap(long, short, value_parser)]
         grain: Option<PathBuf>,
-        /// ISO strength (1-4294967295) for photon-noise-based grain (mutually exclusive with --grain).
-        /// Values between 100-6400 are recommended.
-        #[clap(long, value_parser = clap::value_parser!(u32).range(1..), conflicts_with = "grain")]
+        /// ISO strength for photon-noise-based grain (1–4294967295; 100–6400 recommended).
+        /// Cannot be used together with --grain.
+        #[clap(long, value_parser = clap::value_parser!(u32).range(1..))]
         iso: Option<u32>,
-        /// Whether to apply grain to the chroma planes as well (only valid with --iso).
+        /// Apply photon-noise grain to chroma planes as well as luma (only valid with --iso).
         #[clap(long, requires = "iso")]
         chroma: bool,
-        /// Replace any existing grain headers instead of skipping.
+        /// Overwrite any existing grain headers in the input.
+        /// Without this flag the command skips files that already have grain.
         #[clap(long)]
         replace: bool,
     },
-    /// Removes all film grain from a given AV1 video,
-    /// and outputs it at a given `output` path.
+    /// Strip all film grain synthesis from an AV1 video.
     Remove {
         /// The AV1 file to remove grain from.
         #[clap(value_parser)]
         input: PathBuf,
-        /// The path to write the non-grain-synthed AV1 file to.
+        /// The path to write the grain-free AV1 file to.
         #[clap(long, short, value_parser)]
         output: PathBuf,
         /// Overwrite the output file without prompting.
         #[clap(long, short = 'y')]
         overwrite: bool,
     },
-    /// Compares a source video and a denoised video and generates a film grain
-    /// table based on the difference between them. This will provide the most
-    /// accurate estimation of source film grain.
+    /// Generate a film grain table by diffing a source video against a denoised copy.
+    ///
+    /// This produces the most accurate grain table because it measures the actual
+    /// noise present in the source rather than estimating it.
     Diff {
-        /// The untouched source file to inspect.
+        /// The untouched source file.
         #[clap(value_parser)]
         source: PathBuf,
-        /// The denoised file to inspect.
+        /// The denoised version of the source file.
         #[clap(value_parser)]
         denoised: PathBuf,
-        /// The path to the output film grain table.
+        /// The path to write the output film grain table to.
         #[clap(long, short, value_parser)]
         output: PathBuf,
         /// Overwrite the output file without prompting.

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,53 +201,9 @@ pub fn main() -> Result<()> {
             output,
             overwrite,
             grain,
-        } => {
-            if input == output {
-                error!(
-                    "Input and output paths are the same. This is probably a typo, because this \
-                     would overwrite your input. Exiting."
-                );
-                return Ok(());
-            }
-
-            if output.exists()
-                && !overwrite
-                && !Confirm::new()
-                    .with_prompt(format!(
-                        "File {} exists. Overwrite?",
-                        output.to_string_lossy()
-                    ))
-                    .interact()?
-            {
-                warn!("Not overwriting existing file. Exiting.");
-                return Ok(());
-            }
-
-            let reader = BitstreamReader::open(&input)?;
-            let writer = format::output(&output)?;
-            let grain_data = read_to_string(grain)?;
-            let new_headers = parse_grain_table(&grain_data)?;
-            let mut parser: BitstreamParser<true> = BitstreamParser::with_writer(
-                reader,
-                writer,
-                Some(
-                    new_headers
-                        .into_iter()
-                        .map(|h| h.into())
-                        .collect::<Vec<_>>(),
-                ),
-            );
-
-            parser.modify_grain_headers()?;
-
-            info!("Done, wrote output file to {}", output.to_string_lossy());
-        }
-        Commands::Generate {
-            input,
-            output,
-            overwrite,
             iso,
             chroma,
+            replace,
         } => {
             if input == output {
                 error!(
@@ -270,40 +226,90 @@ pub fn main() -> Result<()> {
                 return Ok(());
             }
 
+            // Check whether the input already carries film grain headers.
+            // We only need to read the Sequence Header OBU (always in the first video packet)
+            // to check the film_grain_params_present flag, so this is effectively instant.
+            let check_reader = BitstreamReader::open(&input)?;
+            let mut check_parser: BitstreamParser<false> = BitstreamParser::new(check_reader);
+            let has_existing_grain = check_parser.film_grain_params_present()?;
+
+            if has_existing_grain && !replace {
+                info!(
+                    "Skipped: grain headers already exist in this file. Re-run with '--replace' \
+                     to replace the existing grain headers."
+                );
+                return Ok(());
+            }
+
+            // Build the grain segments from whichever source was provided.
             let reader = BitstreamReader::open(&input)?;
             let writer = format::output(&output)?;
-            // SAFETY: We extract the items we need from the struct within the unsafe block,
-            // so there's no possibility of use-after-free later.
-            let (width, height, trc, range) = unsafe {
-                let video_stream = reader.get_video_stream().unwrap();
-                let params = video_stream.parameters().as_ptr();
-                (
-                    (*params).width as u32,
-                    (*params).height as u32,
-                    (*params).color_trc,
-                    (*params).color_range,
-                )
+
+            let new_grain = match (grain, iso) {
+                (Some(grain_path), None) => {
+                    let grain_data = read_to_string(grain_path)?;
+                    let new_headers = parse_grain_table(&grain_data)?;
+                    Some(
+                        new_headers
+                            .into_iter()
+                            .map(|h| h.into())
+                            .collect::<Vec<_>>(),
+                    )
+                }
+                (None, Some(iso_value)) => {
+                    // SAFETY: We extract the items we need from the struct within the unsafe
+                    // block, so there's no possibility of use-after-free later.
+                    let (width, height, trc, range) = unsafe {
+                        let video_stream = reader.get_video_stream().unwrap();
+                        let params = video_stream.parameters().as_ptr();
+                        (
+                            (*params).width as u32,
+                            (*params).height as u32,
+                            (*params).color_trc,
+                            (*params).color_range,
+                        )
+                    };
+                    let grain_data = generate_photon_noise_params(
+                        0,
+                        u64::MAX,
+                        av1_grain::NoiseGenArgs {
+                            iso_setting: iso_value,
+                            width,
+                            height,
+                            transfer_function: if trc
+                                == AVColorTransferCharacteristic::SMPTE2084
+                            {
+                                TransferFunction::SMPTE2084
+                            } else {
+                                TransferFunction::BT1886
+                            },
+                            chroma_grain: chroma,
+                            full_range: range == AVColorRange::JPEG,
+                            random_seed: None,
+                        },
+                    );
+                    Some(vec![grain_data.into()])
+                }
+                (None, None) => {
+                    error!(
+                        "Must provide either --grain <FILE> or --iso <NUM> to specify the grain \
+                         source. Exiting."
+                    );
+                    return Ok(());
+                }
+                // clap's conflicts_with prevents both being set simultaneously, but handle it
+                // gracefully in case the logic is ever reached.
+                (Some(_), Some(_)) => {
+                    error!(
+                        "Cannot use --grain and --iso at the same time. Provide one or the \
+                         other. Exiting."
+                    );
+                    return Ok(());
+                }
             };
 
-            let grain_data = generate_photon_noise_params(
-                0,
-                u64::MAX,
-                av1_grain::NoiseGenArgs {
-                    iso_setting: iso,
-                    width,
-                    height,
-                    transfer_function: if trc == AVColorTransferCharacteristic::SMPTE2084 {
-                        TransferFunction::SMPTE2084
-                    } else {
-                        TransferFunction::BT1886
-                    },
-                    chroma_grain: chroma,
-                    full_range: range == AVColorRange::JPEG,
-                    random_seed: None,
-                },
-            );
             let mut parser: BitstreamParser<true> =
-                BitstreamParser::with_writer(reader, writer, Some(vec![grain_data.into()]));
+                BitstreamParser::with_writer(reader, writer, new_grain);
 
             parser.modify_grain_headers()?;
 
@@ -792,8 +798,11 @@ pub enum Commands {
         #[clap(long, short = 'y')]
         overwrite: bool,
     },
-    /// Applies film grain from a table file to a given AV1 video,
-    /// and outputs it at a given `output` path.
+    /// Applies film grain to a given AV1 video and outputs it at a given `output` path.
+    ///
+    /// Provide either `--grain` to use a grain table file, or `--iso` to generate
+    /// photon-noise-based grain. If the input already has film grain headers, processing
+    /// is skipped unless `--replace` is also provided.
     Apply {
         /// The AV1 file to apply grain to.
         #[clap(value_parser)]
@@ -804,28 +813,19 @@ pub enum Commands {
         /// Overwrite the output file without prompting.
         #[clap(long, short = 'y')]
         overwrite: bool,
-        /// The path to the input film grain table.
-        #[clap(long, short, value_parser)]
-        grain: PathBuf,
-    },
-    /// Generates photon-noise-based film grain based on a given ISO value,
-    /// adds it to a given AV1 video, and outputs it at a given `output` path.
-    Generate {
-        /// The AV1 file to apply grain to.
-        #[clap(value_parser)]
-        input: PathBuf,
-        /// The path to write the grain-synthed AV1 file to.
-        #[clap(long, short, value_parser)]
-        output: PathBuf,
-        /// Overwrite the output file without prompting.
-        #[clap(long, short = 'y')]
-        overwrite: bool,
-        /// ISO strength (1-4294967295) for the generated grain. Values between 100-6400 are recommended.
-        #[clap(long, value_parser = clap::value_parser!(u32).range(1..))]
-        iso: u32,
-        /// Whether to apply grain to the chroma planes as well.
-        #[clap(long)]
+        /// The path to a film grain table file to apply (mutually exclusive with --iso).
+        #[clap(long, short, value_parser, conflicts_with = "iso")]
+        grain: Option<PathBuf>,
+        /// ISO strength (1-4294967295) for photon-noise-based grain (mutually exclusive with --grain).
+        /// Values between 100-6400 are recommended.
+        #[clap(long, value_parser = clap::value_parser!(u32).range(1..), conflicts_with = "grain")]
+        iso: Option<u32>,
+        /// Whether to apply grain to the chroma planes as well (only valid with --iso).
+        #[clap(long, requires = "iso")]
         chroma: bool,
+        /// Replace any existing grain headers instead of skipping.
+        #[clap(long)]
+        replace: bool,
     },
     /// Removes all film grain from a given AV1 video,
     /// and outputs it at a given `output` path.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -117,6 +117,50 @@ impl<const WRITE: bool> BitstreamParser<WRITE> {
         (pts * num * 10_000_000u64).div_ceil(den)
     }
 
+    /// Returns `true` if the `film_grain_params_present` flag is set in the stream's Sequence
+    /// Header, and `false` otherwise.
+    ///
+    /// This reads only as far as the first Sequence Header OBU — typically the very start of
+    /// the first video packet — so it is far faster than [`Self::get_grain_headers`] for a
+    /// simple presence check.
+    pub fn film_grain_params_present(&mut self) -> Result<bool> {
+        // Reuse an already-parsed sequence header if available.
+        if let Some(ref sh) = self.sequence_header {
+            return Ok(sh.film_grain_params_present);
+        }
+
+        let mut reader = self.reader.take().unwrap();
+        let stream_idx = reader.get_video_stream()?.index();
+
+        'packets: for (stream, packet) in reader.input().packets().filter_map(Result::ok) {
+            let Some(mut input) = packet.data() else {
+                break;
+            };
+            if stream.index() != stream_idx {
+                continue;
+            }
+            loop {
+                let (remaining, obu) = self
+                    .parse_obu(input, 0)
+                    .finish()
+                    .map_err(|e| anyhow!("{e:?}"))?;
+                input = remaining;
+                if let Some(Obu::SequenceHeader(sh)) = obu {
+                    self.sequence_header = Some(sh);
+                    break 'packets;
+                }
+                if input.is_empty() {
+                    break;
+                }
+            }
+        }
+
+        Ok(self
+            .sequence_header
+            .as_ref()
+            .map_or(false, |sh| sh.film_grain_params_present))
+    }
+
     pub fn get_grain_headers(&mut self) -> Result<&[FilmGrainHeader]> {
         if self.parsed {
             return Ok(&self.grain_headers);


### PR DESCRIPTION
> I'm glad my previous PR was helpful. I'm continuing to adjust this project for my own needs and figured I'd share them here in case it's something that makes sense to you. My main focus this time around was to streamline usage a little.

## Summary

This PR restructures the grain-application commands to reduce surface area, add a safety net against accidentally overwriting existing grain, and improve the CLI help output.

### What changed

- **`apply` and `generate` merged into a single `apply` command.**
  Both commands wrote grain params into the AV1 bitstream in exactly the same way — the only difference was the grain *source*. Having two separate subcommands for the same underlying operation required users to remember which one to use based on their grain source, which was unnecessary. The unified `apply` now accepts either:
  - `--grain <FILE>` — applies grain from a table file (the original `apply` behaviour)
  - `--iso <NUM>` (+ optional `--chroma`) — generates photon-noise-based grain (the original `generate` behaviour)

- **New `--replace` flag with safe-by-default behaviour.**
  Without `--replace`, if the input file already has grain synthesis enabled (detected via `film_grain_params_present` in the Sequence Header), the command prints an informative notice and exits cleanly without writing any output. With `--replace`, it proceeds and overwrites the existing grain. This makes `apply` safe to use in automated workflows — for example, a script that applies grain to every AV1 file in a folder will naturally skip any that already have grain without needing extra logic.

- **`generate` subcommand removed (breaking change).**
  Its functionality is fully covered by `apply --iso`. The removal keeps the CLI surface minimal.

- **clap `ArgGroup` enforces the `--grain`/`--iso` constraint at parse time.**
  A required `ArgGroup` tells clap that exactly one of `--grain` or `--iso` must be provided. This means:
  - The usage line correctly shows `<--grain <GRAIN>|--iso <ISO>>` rather than leaving both optional.
  - Providing both flags produces a clear clap error before any file I/O occurs.
  - Omitting both flags also produces a clear clap error.
  - The `--chroma` flag is still enforced by a `requires = "iso"` attribute.

- **`--help` now shows all subcommand options inline.**
  `flatten_help = true` on the root command causes the top-level `--help` to expand every subcommand's options inline, so users can see `-g`/`--grain`, `--iso`, `--chroma`, `--replace`, `-o`, `-y` etc. without having to run `grav1synth apply --help` separately. The root command also gains a proper `about` description and `--version` flag.

### How the grain presence check works

Detecting whether a file already has grain does **not** require scanning the entire video. The AV1 Sequence Header OBU contains a single `film_grain_params_present` flag that is set by the encoder (or by a prior `apply` run) whenever grain synthesis is in use. This OBU always appears at the very start of the stream — typically in the first few bytes of the first video packet.

A new `BitstreamParser::film_grain_params_present()` method reads packets only until it finds the first Sequence Header OBU and then returns immediately, making the check essentially instantaneous regardless of file size.

### Edge cases

- **`film_grain_params_present = true` but no frames have grain applied.** This is technically valid AV1 but unusual in practice. The check is conservative: we treat the flag as authoritative and require `--replace`. The user is not silently blocked — they receive a clear message telling them exactly what to do.
- **`--grain` and `--iso` provided together.** clap's `ArgGroup` rejects this at argument-parsing time with a clear error before any file I/O occurs.
- **`--chroma` without `--iso`.** clap's `requires` attribute rejects this at parse time.
- **Neither `--grain` nor `--iso` provided.** clap's `ArgGroup` (`.required(true)`) rejects this at parse time.

## Test plan

- [x] `apply <no-grain file> -g <table>` — applies grain normally
- [x] `apply <no-grain file> --iso 400` — applies photon-noise grain normally
- [x] `apply <no-grain file> --iso 400 --chroma` — applies grain to luma + chroma
- [x] `apply <grain file> -g <table>` — prints skip notice, no output written
- [x] `apply <grain file> --iso 400` — prints skip notice, no output written
- [x] `apply <grain file> -g <table> --replace` — overwrites existing grain
- [x] `apply <grain file> --iso 400 --replace` — overwrites existing grain
- [x] `apply <file> -g <table> --iso 400` — clap rejects: "argument '--grain' cannot be used with '--iso'"
- [x] `apply <file> --chroma` (no `--iso`) — clap rejects: requires error
- [x] `apply <file>` (no grain source) — clap rejects: "the following required arguments were not provided: <--grain <GRAIN>|--iso <ISO>>"
- [x] `grav1synth --help` — shows all subcommand options inline including `-g`, `--iso`, `--chroma`, `--replace`
