### PR TITLE
Correctly copy framerate for .ivf

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -228,11 +228,18 @@ impl<const WRITE: bool> BitstreamParser<WRITE> {
             ost.set_parameters(ist.parameters());
             ost.metadata_mut().replace_with(ist_metadata);
             ost.set_sample_aspect_ratio(ist_sar);
-            // SAFETY: We need to set codec_tag to 0 and copy disposition flags.
-            // There's no high level API for either (yet).
+            // SAFETY: We need to set codec_tag to 0, copy disposition flags, set the stream's
+            // time_base, and copy r_frame_rate (critical for IVF and other containers that don't 
+            // store framerate in their header). There's no high level API for these (yet).
             unsafe {
-                (*ost.parameters_mut().as_mut_ptr()).codec_tag = 0;
-                (*ost.as_mut_ptr()).disposition = (*ist.as_ptr()).disposition;
+                let ist_stream = ist.as_ptr();
+                let ost_stream = ost.as_mut_ptr();
+                let ost_params = ost.parameters_mut().as_mut_ptr();
+                
+                (*ost_params).codec_tag = 0;
+                (*ost_stream).r_frame_rate = (*ist_stream).r_frame_rate;
+                (*ost_stream).time_base = (*ist_stream).time_base;
+                (*ost_stream).disposition = (*ist_stream).disposition;
             }
         }
 


### PR DESCRIPTION
When using apply command to .ivf the framerate changed to 90000FPS, now it retains the original framerate.